### PR TITLE
Add html content type to emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # The ultimate source of your information about lucashi
 
+[![Build Status](https://travis-ci.org/Caelink/lucashifacts.svg?branch=master)](https://travis-ci.org/Caelink/lucashifacts)
+
 Literally meme at me

--- a/config.sh
+++ b/config.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 export EMAILS=./list_of_spam
 export MAIL_SCRIPT=./disrupt.sh

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export EMAILS=./list_of_spam
-export MAIL_SCRIPT=./disrupt.sh
-export FACTS_SOURCE=./lucashifacts
+export EMAILS="${HOME}/.local/share/lucashi"
+export MAIL_SCRIPT="./disrupt.sh"
+export FACTS_SOURCE="./lucashifacts"

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -1,5 +1,7 @@
+#!/bin/bash
+
 tmpstring=$(cat template)
 randomfacts=$(shuf -n 1 lucashifacts)
 tmpstring="$tmpstring $randomfacts"
 
-echo "$tmpstring" | /usr/bin/mail -s "lucashi fact of the day" $1
+echo "$tmpstring" | /usr/bin/mail -s "lucashi fact of the day" "$1"

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 randomfacts="$(shuf -n 1 lucashifacts)"
-facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
-export tmpstring="$(eval "echo \"$(cat template)\"")"
+export facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
+export tmpstring
+tmpstring="$(eval "echo \"$(cat template)\"")"
 
 if [ "$#" -eq 1 ]; then
     echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" "$1"

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-tmpstring=$(cat template)
-randomfacts=$(shuf -n 1 lucashifacts)
-tmpstring="$tmpstring $randomfacts"
+randomfacts="$(shuf -n 1 lucashifacts)"
+facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
+tmpstring="$(eval "echo \"$(cat template)\"")"
 
-echo "$tmpstring" | /usr/bin/mail -s "lucashi fact of the day" "$1"
+echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" $1

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+# Export all these variables for SC2155 rule
+export facthtml
+export tmpstring
+
 randomfacts="$(shuf -n 1 lucashifacts)"
-facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
-export tmpstring="$(eval "echo \"$(cat template)\"")"
+facthtml="$(echo "${randomfacts}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
+tmpstring="$(eval "echo \"$(cat template)\"")"
 
 if [ "$#" -eq 1 ]; then
     echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" "$1"

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -2,6 +2,10 @@
 
 randomfacts="$(shuf -n 1 lucashifacts)"
 facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
-tmpstring="$(eval "echo \"$(cat template)\"")"
+export tmpstring="$(eval "echo \"$(cat template)\"")"
 
-echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" $1
+if [ "$#" -eq 1 ]; then
+    echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" "$1"
+else
+    echo "$tmpstring"
+fi

--- a/disrupt.sh
+++ b/disrupt.sh
@@ -1,5 +1,5 @@
-tmpstring=$(cat template)
 randomfacts=$(shuf -n 1 lucashifacts)
-tmpstring="$tmpstring $randomfacts"
+facthtml="$(echo ${randomfacts} | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g')"
+tmpstring=$(eval "echo \"$(cat template)\"")
 
-echo "$tmpstring" | /usr/bin/mail -s "lucashi fact of the day" $1
+echo "$tmpstring" | /usr/bin/mutt -e 'set content_type=text/html' -s "lucashi fact of the day" $1

--- a/list_of_spam
+++ b/list_of_spam
@@ -1,4 +1,0 @@
-k7ding
-lffryzek
-t9chow
-clwalker

--- a/main.sh
+++ b/main.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-TMP_DIR=`mktemp -d lucashifactsi.XXXXXXX` || exit 1
-git clone https://github.com/Caelink/lucashifacts.git $TMP_DIR
+TMP_DIR=$(mktemp -d lucashifactsi.XXXXXXX) || exit 1
+git clone https://github.com/Caelink/lucashifacts.git "$TMP_DIR"
 
-cd $TMP_DIR
+cd "$TMP_DIR" || exit 1
 ./spam_me.sh
-cd -
-rm -rf $TMP_DIR
+cd - || exit 1
+rm -rf "$TMP_DIR"

--- a/spam_me.sh
+++ b/spam_me.sh
@@ -2,4 +2,8 @@
 
 source ./config.sh
 
-< $EMAILS xargs -n 1 $MAIL_SCRIPT
+if [ -r $EMAILS ]; then
+    cat "$EMAILS" | xargs -n 1 "$MAIL_SCRIPT"
+else
+    ./$MAIL_SCRIPT
+fi

--- a/spam_me.sh
+++ b/spam_me.sh
@@ -2,8 +2,8 @@
 
 source ./config.sh
 
-if [ -r $EMAILS ]; then
-    cat "$EMAILS" | xargs -n 1 "$MAIL_SCRIPT"
+if [ -r "$EMAILS" ]; then
+    xargs -n 1 "$MAIL_SCRIPT" < "$EMAILS"
 else
     ./$MAIL_SCRIPT
 fi

--- a/spam_me.sh
+++ b/spam_me.sh
@@ -2,4 +2,4 @@
 
 source ./config.sh
 
-cat $EMAILS | xargs -n 1 $MAIL_SCRIPT
+< $EMAILS xargs -n 1 $MAIL_SCRIPT

--- a/template
+++ b/template
@@ -1,5 +1,8 @@
-hello it is i
-thank you for subscribing to
-lucashi emails
+<html>
+<h1>Hello!</h1>
+<p>it is i<br>
+thank you for subscribing to<br>
+lucashi emails</p>
 
-Did you know that
+<p>Did <em>you</em> know that ${facthtml} </p>
+</html>


### PR DESCRIPTION
This also allows us to send emails to generic email address instead of just UW student emails. This means that list of spam must contain actual email address now. It also opens to the doors to eventually supporting html image tags in emails.

I also have removed the email/username list from the repo as this is generally considered a bad practice.